### PR TITLE
Put all resources into one archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/build_data

--- a/build_win32.sh
+++ b/build_win32.sh
@@ -83,8 +83,8 @@ main() {
   download_add msmpisdk.msi    https://download.microsoft.com/download/D/B/B/DBB64BA1-7B51-43DB-8BF1-D1FB45EACF7A/msmpisdk.msi
   download_add MSMpiSetup.exe  https://download.microsoft.com/download/D/B/B/DBB64BA1-7B51-43DB-8BF1-D1FB45EACF7A/MSMpiSetup.exe
   download_add LLVM.exe        https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe
-  download_add boost32.exe     https://sourceforge.net/projects/boost/files/boost-binaries/$boost_version/boost_$b_name-msvc-$boost_abi_tag-32.exe
-  download_add boost64.exe     https://sourceforge.net/projects/boost/files/boost-binaries/$boost_version/boost_$b_name-msvc-$boost_abi_tag-64.exe
+  #download_add boost32.exe     https://sourceforge.net/projects/boost/files/boost-binaries/$boost_version/boost_$b_name-msvc-$boost_abi_tag-32.exe
+  #download_add boost64.exe     https://sourceforge.net/projects/boost/files/boost-binaries/$boost_version/boost_$b_name-msvc-$boost_abi_tag-64.exe
 
   add win32/pkg-config.exe
   add win32/setdllcharacteristics.exe
@@ -97,7 +97,7 @@ main() {
   msg "Creating $OUT"
   old_pwd="$PWD"
   pushd $ARCHIVE_DIR  &> /dev/null
-  zip -9rq "$old_pwd/$OUT" * || die "Failed to create $OUT"
+  zip -rq "$old_pwd/$OUT" * || die "Failed to create $OUT"
   popd &> /dev/null
   msg "DONE"
 }

--- a/build_win32.sh
+++ b/build_win32.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+REQUIRED=(wget curl sed zip unzip)
+
+BUILD_DIR=build_data
+DOWNLOAD_DIR=$BUILD_DIR/downloads
+ARCHIVE_DIR=$BUILD_DIR/ci_data
+OUT=$BUILD_DIR/ci_data.zip
+
+boost_version='1.72.0'
+boost_abi_tag='14.1'
+
+errors=0
+
+# Go to the root dir
+cd "$(dirname "$0")"
+
+error() { echo -e "\x1b[31;1mERROR:\x1b[37m $*\x1b[0m"; (( errors++ )); }
+msg()   { echo -e "\x1b[32;1m==> \x1b[37m$*\x1b[0m"; }
+exit_on_error() { (( errors > 0 )) && exit 1; }
+die()   { error "$*"; exit 1; }
+
+check_programs() {
+  local i errors
+  errors=0
+  for i in "${REQUIRED[@]}"; do
+    which $i &> /dev/null || error "Missing program $i"
+  done
+  exit_on_error
+}
+
+setup_build_dir() {
+  msg "Build dir is '$BUILD_DIR'"
+  [ -e $BUILD_DIR ] && rm -rf $BUILD_DIR
+  mkdir $BUILD_DIR
+  mkdir $DOWNLOAD_DIR
+  mkdir $ARCHIVE_DIR
+}
+
+add() {
+  [ ! -e "$1" ] && die "$1 does not exist"
+  cp --recursive "$1" "$ARCHIVE_DIR"
+}
+
+download() {
+  msg "Downloading '$1' from '$2'"
+  wget $2 -O $DOWNLOAD_DIR/$1 -q --show-progress || die "Download failed" # &> /dev/null
+}
+
+download_add() {
+  download "$1" "$2"
+  add "$DOWNLOAD_DIR/$1"
+}
+
+extract() {
+  unzip "$DOWNLOAD_DIR/$1" -d $DOWNLOAD_DIR &> /dev/null
+}
+
+configure_install() {
+  [ ! -e $BUILD_DIR/install.ps1 ] && cp win32/install.ps1 $BUILD_DIR
+  sed -i "s/@$1@/$2/g" $BUILD_DIR/install.ps1
+}
+
+
+main() {
+  check_programs
+  setup_build_dir
+
+  b_name="${boost_version//./_}"
+
+  # Ninja
+  download ninja.zip https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-win.zip
+  extract  ninja.zip
+  add      $DOWNLOAD_DIR/ninja.exe
+
+  # DmD
+  dmd_version="$(curl http://downloads.dlang.org/releases/LATEST 2>/dev/null)"
+  dmd_url="http://downloads.dlang.org/releases/2.x/$dmd_version/dmd.$dmd_version.windows.zip"
+  download dmd.zip "$dmd_url"
+  extract  dmd.zip
+  add      $DOWNLOAD_DIR/dmd2
+
+  download_add msmpisdk.msi    https://download.microsoft.com/download/D/B/B/DBB64BA1-7B51-43DB-8BF1-D1FB45EACF7A/msmpisdk.msi
+  download_add MSMpiSetup.exe  https://download.microsoft.com/download/D/B/B/DBB64BA1-7B51-43DB-8BF1-D1FB45EACF7A/MSMpiSetup.exe
+  download_add LLVM.exe        https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe
+  download_add boost32.exe     https://sourceforge.net/projects/boost/files/boost-binaries/$boost_version/boost_$b_name-msvc-$boost_abi_tag-32.exe
+  download_add boost64.exe     https://sourceforge.net/projects/boost/files/boost-binaries/$boost_version/boost_$b_name-msvc-$boost_abi_tag-64.exe
+
+  add win32/pkg-config.exe
+  add win32/setdllcharacteristics.exe
+
+  configure_install BOOST_FILENAME "$b_name"
+  configure_install BOOST_ABI_TAG  "$boost_abi_tag"
+  add $BUILD_DIR/install.ps1
+
+  # package
+  msg "Creating $OUT"
+  old_pwd="$PWD"
+  pushd $ARCHIVE_DIR  &> /dev/null
+  zip -9rq "$old_pwd/$OUT" * || die "Failed to create $OUT"
+  popd &> /dev/null
+  msg "DONE"
+}
+
+main

--- a/win32/install.ps1
+++ b/win32/install.ps1
@@ -1,0 +1,105 @@
+param (
+  [string]$Arch     = "x64",
+  [string]$Compiler = $null,
+  [bool]$Boost      = $false,
+  [bool]$DMD        = $false
+)
+
+echo ""
+echo "=== BEGIN INSTALL ==="
+
+$ScriptDir = Split-Path $script:MyInvocation.MyCommand.Path
+
+# Add downloaded files to path
+$env:Path = "$ScriptDir;$env:Path"
+
+# Install installers
+echo " - Installing msi packages"
+Start-Process msiexec.exe -ArgumentList '/i msmpisdk.msi /quiet' -Wait
+Start-Process $ScriptDir\MSMpiSetup.exe -ArgumentList '-unattend -full' -Wait
+
+# import ms-mpi env vars (set by installer)
+foreach ($p in "MSMPI_INC", "MSMPI_LIB32", "MSMPI_LIB64") {
+  $v = [Environment]::GetEnvironmentVariable($p, "Machine")
+  Set-Content "env:$p" "$v"
+}
+
+if ($Boost) {
+  if ($Arch -eq "x64") { $BoostBitness = "64" } else { $BoostBitness = "32" }
+  echo " - Installing $BoostBitness bit boost"
+  Start-Process $ScriptDir\boost$BoostBitness.exe -ArgumentList "/dir=$env:AGENT_WORKFOLDER\boost_@BOOST_FILENAME@ /silent" -Wait
+  $env:BOOST_ROOT = "$env:AGENT_WORKFOLDER\boost_@BOOST_FILENAME@"
+  $env:Path       = "$env:Path;$env:BOOST_ROOT\lib$BoostBitness-msvc-@BOOST_ABI_TAG@"
+}
+
+if ($DMD) {
+  echo " - Installing DMD"
+  $dmd_bin  = Join-Path $ScriptDir "dmd2\windows\bin"
+  $env:Path = $env:Path + ";" + $dmd_bin
+
+  & dmd.exe --version
+
+  if ($Arch -eq "x64") { $dmdArch = "x86_64" } else { $dmdArch = "x86_mscoff" }
+  & dub fetch urld
+  & dub build urld --compiler=dmd --arch=$dmdArch
+  & dub fetch dubtestproject
+  & dub build dubtestproject:test1 --compiler=dmd --arch=$dmdArch
+  & dub build dubtestproject:test2 --compiler=dmd --arch=$dmdArch
+}
+
+echo " - Importing the correct vcvarsall.bat"
+
+# test_find_program exercises some behaviour which relies on .py being in PATHEXT
+$env:PATHEXT += ';.py'
+
+$origPath = $env:Path
+# import visual studio variables
+if ($Compiler -eq 'msvc2019') {
+  $vcvars = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"
+} else {
+  # Note: this is also for clangcl
+  $vcvars = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"
+}
+
+## A multiline commit message containing "=" can interact badly with this
+## hack to extract the environment from vcvarsall.bat
+Remove-Item env:BUILD_SOURCEVERSIONMESSAGE
+
+## ask cmd.exe to output the environment table after the batch file completes
+$tempFile = [IO.Path]::GetTempFileName()
+cmd /c " `"$vcvars`" $env:arch && set > `"$tempFile`" "
+
+## go through the environment variables in the temp file.
+## for each of them, set the variable in our local environment.
+Get-Content $tempFile | Foreach-Object {
+  if($_ -match "^(.*?)=(.*)$") {
+    Set-Content "env:\$($matches[1])" $matches[2]
+  }
+}
+Remove-Item $tempFile
+
+if ($Compiler -eq 'clang-cl') {
+  echo " - Installing LLVM"
+  # drop visual studio from PATH
+  # (but leave INCLUDE, LIB and WindowsSdkDir environment variables set)
+  $env:Path = $origPath
+
+  # install llvm for clang-cl builds
+  Start-Process $ScriptDir\LLVM.exe -ArgumentList '/S' -Wait
+  $env:Path = "C:\Program Files\LLVM\bin;$env:Path"
+  $env:CC   = "clang-cl"
+  $env:CXX  = "clang-cl"
+
+  # and use Windows SDK tools
+  $env:Path = "$env:WindowsSdkDir\bin\$Arch;$env:Path"
+}
+
+# add .NET framework tools to path for resgen for C# tests
+# (always use 32-bit tool, as there doesn't seem to be a 64-bit tool)
+if ((Get-Command "resgen.exe" -ErrorAction SilentlyContinue) -eq $null) {
+  $env:Path = "$env:WindowsSDK_ExecutablePath_x86;$env:Path"
+}
+
+echo "=== END INSTALL ==="
+echo ""
+

--- a/win32/install.ps1
+++ b/win32/install.ps1
@@ -25,11 +25,13 @@ foreach ($p in "MSMPI_INC", "MSMPI_LIB32", "MSMPI_LIB64") {
 }
 
 if ($Boost) {
-  if ($Arch -eq "x64") { $BoostBitness = "64" } else { $BoostBitness = "32" }
-  echo " - Installing $BoostBitness bit boost"
-  Start-Process $ScriptDir\boost$BoostBitness.exe -ArgumentList "/dir=$env:AGENT_WORKFOLDER\boost_@BOOST_FILENAME@ /silent" -Wait
-  $env:BOOST_ROOT = "$env:AGENT_WORKFOLDER\boost_@BOOST_FILENAME@"
-  $env:Path       = "$env:Path;$env:BOOST_ROOT\lib$BoostBitness-msvc-@BOOST_ABI_TAG@"
+  echo " - Using preinstalled boost version: $env:BOOST_ROOT"
+
+  # if ($Arch -eq "x64") { $BoostBitness = "64" } else { $BoostBitness = "32" }
+  # echo " - Installing $BoostBitness bit boost"
+  # Start-Process $ScriptDir\boost$BoostBitness.exe -ArgumentList "/dir=$env:AGENT_WORKFOLDER\boost_@BOOST_FILENAME@ /silent" -Wait
+  # $env:BOOST_ROOT = "$env:AGENT_WORKFOLDER\boost_@BOOST_FILENAME@"
+  # $env:Path       = "$env:Path;$env:BOOST_ROOT\lib$BoostBitness-msvc-@BOOST_ABI_TAG@"
 }
 
 if ($DMD) {


### PR DESCRIPTION
Adds a script to bundle all binaries into one big zip file. This file can then be attached to a GitHub release, which provides a stable link for the CI. GitHub release files can be [up to 2GB](https://help.github.com/en/github/managing-large-files/distributing-large-binaries). Se [my fork](https://github.com/mensinda/cidata/releases/tag/ci1) for a currently working setup.

Related PR: mesonbuild/meson#6875